### PR TITLE
Remove cudatoolkit-dev from recipe

### DIFF
--- a/tensorrt/0204-update-Makefile.conf-for-conda-builds.patch
+++ b/tensorrt/0204-update-Makefile.conf-for-conda-builds.patch
@@ -1,5 +1,5 @@
---- Makefile.config	2019-12-17 02:22:07.000000000 +0000
-+++ Makefile.config	2020-10-01 18:20:13.758644894 +0000
+--- samples/Makefile.config	2019-12-17 02:22:07.000000000 +0000
++++ samples/Makefile.config	2020-10-01 18:20:13.758644894 +0000
 @@ -10,9 +10,9 @@ ifeq ($(CUDNN_INSTALL_DIR),)
  $(warning CUDNN_INSTALL_DIR variable is not specified, using $$CUDA_INSTALL_DIR by default, use CUDNN_INSTALL_DIR=<cudnn_directory> to change.)
  endif

--- a/tensorrt/0204-update-Makefile.conf-for-conda-builds.patch
+++ b/tensorrt/0204-update-Makefile.conf-for-conda-builds.patch
@@ -1,5 +1,5 @@
 --- Makefile.config	2019-12-17 02:22:07.000000000 +0000
-+++ Makefile.config.1	2020-10-01 18:20:13.758644894 +0000
++++ Makefile.config	2020-10-01 18:20:13.758644894 +0000
 @@ -10,9 +10,9 @@ ifeq ($(CUDNN_INSTALL_DIR),)
  $(warning CUDNN_INSTALL_DIR variable is not specified, using $$CUDA_INSTALL_DIR by default, use CUDNN_INSTALL_DIR=<cudnn_directory> to change.)
  endif

--- a/tensorrt/0204-update-Makefile.conf-for-conda-builds.patch
+++ b/tensorrt/0204-update-Makefile.conf-for-conda-builds.patch
@@ -1,12 +1,10 @@
---- samples/Makefile.config	2020-01-02 15:00:49.080019527 +0000
-+++ samples/Makefile.config	2020-01-02 15:34:46.216668825 +0000
-@@ -9,10 +9,10 @@
- ifeq ($(CUDNN_INSTALL_DIR),)
+--- Makefile.config	2019-12-17 02:22:07.000000000 +0000
++++ Makefile.config.1	2020-10-01 18:20:13.758644894 +0000
+@@ -10,9 +10,9 @@ ifeq ($(CUDNN_INSTALL_DIR),)
  $(warning CUDNN_INSTALL_DIR variable is not specified, using $$CUDA_INSTALL_DIR by default, use CUDNN_INSTALL_DIR=<cudnn_directory> to change.)
  endif
--CUDA_INSTALL_DIR?=/usr/local/cuda
+ CUDA_INSTALL_DIR?=/usr/local/cuda
 -CUDNN_INSTALL_DIR?=$(CUDA_INSTALL_DIR)
-+CUDA_INSTALL_DIR?=$(CONDA_PREFIX)
 +CUDNN_INSTALL_DIR?=$(CONDA_PREFIX)
  CUDA_LIBDIR=lib
 -CUDNN_LIBDIR=lib64
@@ -14,17 +12,24 @@
  ifeq ($(TARGET), aarch64)
  ifeq ($(shell uname -m), aarch64)
  CUDA_LIBDIR=lib64
-@@ -26,7 +26,8 @@
- CC = g++
+@@ -22,12 +22,12 @@ CC = aarch64-linux-gnu-g++
+ endif
+ CUCC =$(CUDA_INSTALL_DIR)/bin/nvcc -m64 -ccbin $(CC)
+ else ifeq ($(TARGET), x86_64)
+-CUDA_LIBDIR=lib64
+-CC = g++
++CUDA_LIBDIR=lib
++CC = x86_64-conda_cos6-linux-gnu-g++
  CUCC =$(CUDA_INSTALL_DIR)/bin/nvcc -m64
  else ifeq ($(TARGET), ppc64le)
 -CUDA_LIBDIR=lib64
+-CC = g++
 +CUDA_LIBDIR=lib
-+CUDNN_LIBDIR=lib
- CC = g++
++CC = powerpc64le-conda_cos7-linux-gnu-g++
  CUCC = $(CUDA_INSTALL_DIR)/bin/nvcc -m64
  else ifeq ($(TARGET), qnx)
-@@ -99,7 +100,7 @@
+ CC = ${QNX_HOST}/usr/bin/aarch64-unknown-nto-qnx7.0.0-g++
+@@ -99,7 +99,7 @@ ifeq ($(TARGET), qnx)
  COMMON_FLAGS += -D_POSIX_C_SOURCE=200112L -D_QNX_SOURCE -D_FILE_OFFSET_BITS=64 -fpermissive
  endif
  

--- a/tensorrt/0204-update-Makefile.conf-for-conda-builds.patch
+++ b/tensorrt/0204-update-Makefile.conf-for-conda-builds.patch
@@ -1,5 +1,5 @@
---- samples/Makefile.config	2019-12-17 02:22:07.000000000 +0000
-+++ samples/Makefile.config	2020-10-01 18:20:13.758644894 +0000
+--- samples/Makefile.config	2019-12-16 20:22:07.000000000 -0600
++++ samples/Makefile.config	2020-10-09 12:43:02.289057820 -0500
 @@ -10,9 +10,9 @@ ifeq ($(CUDNN_INSTALL_DIR),)
  $(warning CUDNN_INSTALL_DIR variable is not specified, using $$CUDA_INSTALL_DIR by default, use CUDNN_INSTALL_DIR=<cudnn_directory> to change.)
  endif
@@ -29,12 +29,3 @@
  CUCC = $(CUDA_INSTALL_DIR)/bin/nvcc -m64
  else ifeq ($(TARGET), qnx)
  CC = ${QNX_HOST}/usr/bin/aarch64-unknown-nto-qnx7.0.0-g++
-@@ -99,7 +99,7 @@ ifeq ($(TARGET), qnx)
- COMMON_FLAGS += -D_POSIX_C_SOURCE=200112L -D_QNX_SOURCE -D_FILE_OFFSET_BITS=64 -fpermissive
- endif
- 
--COMMON_LD_FLAGS += $(LIBPATHS) -L$(OUTDIR)
-+COMMON_LD_FLAGS += $(LIBPATHS) -L$(OUTDIR) -Wl,--rpath=$(CONDA_PREFIX)/lib
- 
- OBJDIR    =$(call concat,$(OUTDIR),/chobj)
- DOBJDIR   =$(call concat,$(OUTDIR),/dchobj)

--- a/tensorrt/meta.yaml
+++ b/tensorrt/meta.yaml
@@ -44,7 +44,7 @@ build:
   string: cuda{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
   activate_in_script: True
   script_env:
-    - CUDA_HOME
+    - OPEN_CE_CUDA_HOME
 
 outputs:
    - name: tensorrt

--- a/tensorrt/meta.yaml
+++ b/tensorrt/meta.yaml
@@ -40,7 +40,7 @@ source:
     folder: TensorRT
 
 build:
-  number: 1
+  number: 2
   string: cuda{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
   activate_in_script: True
   script_env:

--- a/tensorrt/meta.yaml
+++ b/tensorrt/meta.yaml
@@ -43,8 +43,6 @@ build:
   number: 2
   string: cuda{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
   activate_in_script: True
-  script_env:
-    - OPEN_CE_CUDA_HOME
 
 outputs:
    - name: tensorrt
@@ -52,7 +50,6 @@ outputs:
      requirements:
          build:
            - {{ compiler('cxx') }}
-           - {{ compiler('cuda') }}
            - cmake {{ cmake }}
            - make {{ make }}
          host:
@@ -76,7 +73,6 @@ outputs:
      requirements:
          build:
            - {{ compiler('cxx') }}
-           - {{ compiler('cuda') }}
            - cmake {{ cmake }}
            - make {{ make }}
          host:

--- a/tensorrt/meta.yaml
+++ b/tensorrt/meta.yaml
@@ -43,6 +43,8 @@ build:
   number: 1
   string: cuda{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
   activate_in_script: True
+  script_env:
+    - CUDA_HOME
 
 outputs:
    - name: tensorrt
@@ -50,11 +52,11 @@ outputs:
      requirements:
          build:
            - {{ compiler('cxx') }}
+           - {{ compiler('cuda') }}
            - cmake {{ cmake }}
            - make {{ make }}
          host:
            - python {{ python }}
-           - cudatoolkit-dev {{ cudatoolkit }}
            - protobuf {{ protobuf }}
            - libprotobuf {{ protobuf }}
            - cudnn {{ cudnn }}
@@ -74,11 +76,11 @@ outputs:
      requirements:
          build:
            - {{ compiler('cxx') }}
+           - {{ compiler('cuda') }}
            - cmake {{ cmake }}
            - make {{ make }}
          host:
            - python {{ python }}
-           - cudatoolkit-dev {{ cudatoolkit }}
            - protobuf {{ protobuf }}
            - libprotobuf {{ protobuf }}
            - cudnn {{ cudnn }}
@@ -95,7 +97,6 @@ outputs:
            - requests {{ requests }}
            - cmake {{ cmake }}
            - make  {{ make }}
-           - cudatoolkit-dev {{ cudatoolkit }}
            - numpy {{ numpy }}
            - gxx_linux-64       {{ cxx_compiler_version }} # [x86_64]
            - gxx_linux-ppc64le  {{ cxx_compiler_version }} # [ppc64le]


### PR DESCRIPTION
This switches the TRT recipe to use the `nvcc` metapackage instead of `cudatoolkit-dev`

closes: #5 

requires: https://github.com/open-ce/nvcc-feedstock/pull/3